### PR TITLE
Support custom actions in the views

### DIFF
--- a/lib/rummage_phoenix/hooks/views/paginate_view.ex
+++ b/lib/rummage_phoenix/hooks/views/paginate_view.ex
@@ -66,12 +66,15 @@ defmodule Rummage.Phoenix.PaginateView do
 
     per_page = paginate_params.per_page
     label = Keyword.get(opts, :all_label, "All")
+    action = Keyword.get(opts, :action, :index)
 
     case per_page == -1 do
       true -> page_link "#", :disabled, do: label
       false ->
-        page_link index_path(opts, [conn, :index,
-          transform_params(rummage, -1, 1, opts)]), do: label
+        page_link(
+          index_path(opts, [conn, action, transform_params(rummage, -1, 1, opts)]),
+          do: label
+        )
     end
   end
 
@@ -96,11 +99,21 @@ defmodule Rummage.Phoenix.PaginateView do
       page = paginate_params.page
       per_page = paginate_params.per_page
       label = Keyword.get(opts, :first_label, "First")
+      action = Keyword.get(opts, :action, :index)
 
       case page == 1 do
-        true -> theme_adapter.page_link("#", :disabled, do: label)
-        false -> theme_adapter.page_link(index_path(opts, [conn, :index,
-            transform_params(rummage, per_page, 1, opts)]), do: label)
+        true ->
+          theme_adapter.page_link("#", :disabled, do: label)
+
+        false ->
+          theme_adapter.page_link(
+            index_path(opts, [
+              conn,
+              action,
+              transform_params(rummage, per_page, 1, opts)
+            ]),
+            do: label
+          )
       end
     end
   end
@@ -111,12 +124,16 @@ defmodule Rummage.Phoenix.PaginateView do
     page = paginate_params.page
     per_page = paginate_params.per_page
     label = opts[:previous_label] || "Previous"
+    action = Keyword.get(opts, :action, :index)
 
     case page <= 1 do
-      true -> page_link "#", :disabled, do: label
+      true ->
+        page_link("#", :disabled, do: label)
+
       false ->
         page_link index_path(opts, [conn, :index,
           transform_params(rummage, per_page, page - 1, opts)]), do: label
+            action,
     end
   end
 
@@ -127,6 +144,7 @@ defmodule Rummage.Phoenix.PaginateView do
     per_page = paginate_params.per_page
     max_page = paginate_params.max_page
     max_page_links = opts[:max_page_links] || 5 #Rummage.Phoenix.default_max_page_links
+    action = Keyword.get(opts, :action, :index)
 
     lower_limit = cond do
       page <= div(max_page_links, 2) -> 1
@@ -143,6 +161,7 @@ defmodule Rummage.Phoenix.PaginateView do
         true ->
           page_link index_path(opts, [conn, :index,
             transform_params(rummage, per_page, page_num, opts)]), do: page_num
+              action,
       end
     end)
   end
@@ -154,12 +173,14 @@ defmodule Rummage.Phoenix.PaginateView do
     per_page = paginate_params.per_page
     max_page = paginate_params.max_page
     label = opts[:next_label] || "Next"
+    action = Keyword.get(opts, :action, :index)
 
     case page >= max_page do
       true -> page_link "#", :disabled, do: label
       false ->
         page_link index_path(opts, [conn, :index,
           transform_params(rummage, per_page, page + 1, opts)]), do: label
+            action,
     end
   end
 
@@ -171,12 +192,14 @@ defmodule Rummage.Phoenix.PaginateView do
     # max_page_links = String.to_integer(paginate_params["max_page_links"] || "4")
     max_page = paginate_params.max_page
     label = opts[:last_label] || "Last"
+    action = Keyword.get(opts, :action, :index)
 
     case page == max_page do
       true -> page_link "#", :disabled, do: label
       false ->
         page_link index_path(opts, [conn, :index,
           transform_params(rummage, per_page, max_page, opts)]), do: label
+            action,
     end
   end
 

--- a/lib/rummage_phoenix/hooks/views/search_view.ex
+++ b/lib/rummage_phoenix/hooks/views/search_view.ex
@@ -49,6 +49,7 @@ defmodule Rummage.Phoenix.SearchView do
     search = rummage["search"]
     sort = if rummage["sort"], do: Poison.encode!(rummage["sort"]), else: ""
     paginate = if rummage["paginate"], do: Poison.encode!(rummage["paginate"]), else: ""
+    action = Keyword.get(opts, :action, :index)
 
     button_class = Keyword.get(link_params, :button_class, "btn btn-primary")
     button_label = Keyword.get(link_params, :button_label, "Search")
@@ -56,7 +57,7 @@ defmodule Rummage.Phoenix.SearchView do
 
     form_for(conn, apply(opts[:helpers], String.to_atom("#{opts[:struct]}_path"), [conn, :index]), [as: :rummage, method: :get], fn(f) ->
       {
-        :safe,
+      apply(opts[:helpers], String.to_atom("#{opts[:struct]}_path"), [conn, action]),
         elem(hidden_input(f, :sort, value: sort, class: "form-control"), 1) ++
         elem(hidden_input(f, :paginate, value: paginate, class: "form-control"), 1) ++
         elem(inputs_for(f, :search, fn(s) ->

--- a/lib/rummage_phoenix/hooks/views/sort_view.ex
+++ b/lib/rummage_phoenix/hooks/views/sort_view.ex
@@ -55,6 +55,7 @@ defmodule Rummage.Phoenix.SortView do
     desc_icon = Keyword.get(opts, :desc_icon)
     desc_text = Keyword.get(opts, :desc_text, "↓")
     rummage_key = Keyword.get(opts, :rummage_key, :rummage)
+    action = Keyword.get(opts, :action, :index)
 
     # Drop pagination unless we're showing the entire result set
     rummage_params = if rummage.params.paginate && rummage.params.paginate.per_page == -1 do
@@ -76,14 +77,14 @@ defmodule Rummage.Phoenix.SortView do
           rummage_params = rummage_params
           |> Map.put(:sort, %{name: field, order: "asc"})
 
-          url = index_path(opts, [conn, :index, %{rummage_key => rummage_params}])
+          url = index_path(opts, [conn, action, %{rummage_key => rummage_params}])
           # sort_text_or_image(url, [img: asc_icon, text: asc_text], name)
       end
     else
       rummage_params = rummage_params
       |> Map.put(:sort, %{name: field, order: "asc"})
 
-      url = index_path(opts, [conn, :index, %{rummage_key => rummage_params}])
+      url = index_path(opts, [conn, action, %{rummage_key => rummage_params}])
       # sort_text_or_image(url, [], name)
     end
   end


### PR DESCRIPTION
These changes allow us to add the "action:" optional arg to the views of paginate, search and sort functions to support custom actions different from index. If no option is provided, it defaults to ":index" action.


Example:
```elixir
<%= pagination_links(@conn, @rummage, action: :list_industries) %>
```

